### PR TITLE
Update Docker build steps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+integration
+README.md
+.circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM golang:alpine
+FROM golang:alpine as build-env
 
 RUN apk add build-base linux-headers
-ADD . /go/src/github.com/smartcontractkit/external-initiator
-RUN cd /go/src/github.com/smartcontractkit/external-initiator && go get && go build
+RUN mkdir /external-initiator
+WORKDIR /external-initiator
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/external-initiator
+
+FROM scratch
+COPY --from=build-env /go/bin/external-initiator /go/bin/external-initiator
 
 EXPOSE 8080
 
-ENTRYPOINT ["external-initiator"]
+ENTRYPOINT ["/go/bin/external-initiator"]

--- a/integration/mock-client/Dockerfile
+++ b/integration/mock-client/Dockerfile
@@ -1,9 +1,17 @@
-FROM golang:alpine
+FROM golang:alpine as build-env
 
-RUN apk add build-base
-ADD . /go/src/github.com/smartcontractkit/external-initiator/integration/mock-client
-RUN cd /go/src/github.com/smartcontractkit/external-initiator/integration/mock-client && go get && go build
+RUN apk add build-base linux-headers
+RUN mkdir /mock-client
+WORKDIR /mock-client
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/mock-client
+
+FROM scratch
+COPY --from=build-env /go/bin/mock-client /go/bin/mock-client
 
 EXPOSE 8080
 
-ENTRYPOINT ["mock-client"]
+ENTRYPOINT ["/go/bin/mock-client"]


### PR DESCRIPTION
This should avoid re-downloading dependencies if they have not changed, and will also not re-build when running integration tests where nothing has changed.