### PR TITLE
Avoid unnecessary authentication in integration tests

### DIFF
--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -1,2 +1,3 @@
 external_initiator.env
 tmp/
+cl_login.txt

--- a/integration/common
+++ b/integration/common
@@ -46,6 +46,10 @@ launch_chainlink() {
   title "Chainlink is running."
 }
 
+login_chainlink() {
+  docker exec integration_chainlink chainlink admin login -f /run/secrets/apicredentials
+}
+
 run_ei() {
   title "Running External Initiator..."
 
@@ -120,11 +124,13 @@ build_docker() {
   title "Done building Docker images"
 }
 
-reset_volumes() {
+reset() {
   title "Removing Docker volumes"
 
   docker volume rm integration_cl || :
   docker volume rm integration_pg || :
+
+  rm ./integration/cl_login.txt || :
 
   title "Done removing Docker volumes"
 }

--- a/integration/run_test
+++ b/integration/run_test
@@ -12,7 +12,7 @@ run_test() {
   title "Initiating a fresh test"
 
   # Remove old volumes so we can run a fresh test
-  reset_volumes
+  reset
 
   start_docker
 
@@ -20,6 +20,8 @@ run_test() {
 
   # Run EI after access credentials has been generated
   run_ei
+
+  login_chainlink
 
   ./integration/test_ei_event "eth-mock-http"
   ./integration/test_ei_event "eth-mock-ws"

--- a/integration/scripts/package.json
+++ b/integration/scripts/package.json
@@ -13,9 +13,9 @@
     "create-job": "node ./dist/createJob"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "chalk": "^2.4.2",
     "request": "^2.88.2",
-    "request-promise": "4.2.4",
     "source-map-support": "^0.5.13"
   },
   "devDependencies": {

--- a/integration/scripts/src/addExternalInitiator.ts
+++ b/integration/scripts/src/addExternalInitiator.ts
@@ -1,8 +1,8 @@
 // @ts-ignore
 import url from 'url'
-import {credentials, getArgs, registerPromiseHandler,} from './common'
+import {getArgs, getLoginCookie, registerPromiseHandler,} from './common'
 
-const request = require('request-promise').defaults({jar: true});
+const axios = require('axios')
 
 async function main() {
     registerPromiseHandler();
@@ -26,21 +26,25 @@ async function addExternalInitiator({
                                         chainlinkUrl,
                                     }: Options) {
     const sessionsUrl = url.resolve(chainlinkUrl, '/sessions');
-    await request.post(sessionsUrl, {json: credentials});
-
     const externalInitiatorsUrl = url.resolve(chainlinkUrl, '/v2/external_initiators');
-    const externalInitiator = await request.post(externalInitiatorsUrl, {
-        json: {
+    const externalInitiator = await axios.post(externalInitiatorsUrl,
+        {
             name: "mock-client",
             url: url.resolve(initiatorUrl, "/jobs")
+        },
+        {
+            withCredentials: true,
+            headers: {
+                Cookie: await getLoginCookie(sessionsUrl)
+            }
         }
-    }).catch((e: any) => {
+    ).catch((e: any) => {
         console.error(e);
         throw Error(`Error creating EI ${e}`)
     });
 
-    console.log(`EI incoming accesskey: ${externalInitiator.data.attributes.incomingAccessKey}`);
-    console.log(`EI incoming secret: ${externalInitiator.data.attributes.incomingSecret}`);
-    console.log(`EI outgoing token: ${externalInitiator.data.attributes.outgoingToken}`);
-    console.log(`EI outgoing secret: ${externalInitiator.data.attributes.outgoingSecret}`)
+    console.log(`EI incoming accesskey: ${externalInitiator.data.data.attributes.incomingAccessKey}`);
+    console.log(`EI incoming secret: ${externalInitiator.data.data.attributes.incomingSecret}`);
+    console.log(`EI outgoing token: ${externalInitiator.data.data.attributes.outgoingToken}`);
+    console.log(`EI outgoing secret: ${externalInitiator.data.data.attributes.outgoingSecret}`)
 }

--- a/integration/scripts/yarn.lock
+++ b/integration/scripts/yarn.lock
@@ -111,6 +111,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -122,11 +129,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-bluebird@^3.5.0:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -207,6 +209,13 @@ debug@4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.0.1:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -264,6 +273,13 @@ find-replace@^1.0.3:
   dependencies:
     array-back "^1.0.4"
     test-value "^2.1.0"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -409,7 +425,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-lodash@^4.17.11, lodash@^4.17.15:
+lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -444,6 +460,11 @@ mkdirp@^0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@^2.1.1:
   version "2.1.2"
@@ -496,23 +517,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-request-promise-core@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
-  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
-  dependencies:
-    lodash "^4.17.11"
-
-request-promise@4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
-  integrity sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==
-  dependencies:
-    bluebird "^3.5.0"
-    request-promise-core "1.1.2"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
 
 request@^2.88.2:
   version "2.88.2"
@@ -585,11 +589,6 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stealthy-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -605,7 +604,7 @@ test-value@^2.1.0:
     array-back "^1.0.3"
     typical "^2.6.0"
 
-tough-cookie@^2.3.3, tough-cookie@~2.5.0:
+tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==

--- a/integration/test_ei_event
+++ b/integration/test_ei_event
@@ -9,8 +9,6 @@ title "EI event test using $1"
 event_test() {
   trap exit_handler EXIT
 
-  docker exec integration_chainlink chainlink admin login -f /run/secrets/apicredentials
-
   expected_job_count=$(expr "$(docker exec integration_chainlink chainlink -j jobs list | jq length)" + 1)
   local log=$LOG_PATH/send_event_transaction.log
 


### PR DESCRIPTION
In our integration tests we would authenticate for almost every single request to the Chainlink node. The authentication endpoint in the Chainlink node appears to have stricter ratelimiting compared to the other routes, which meant we hit the ratelimit on larger integration tests.

This PR should reduce this down to authentication of the two services that will be making requests: docker and nodejs. These services will re-use their authentication cookie. There is no mechanism to automatically re-authenticate if the session expires.