### PR TITLE
Harmony initiator

### DIFF
--- a/blockchain/common.go
+++ b/blockchain/common.go
@@ -16,6 +16,7 @@ var ExpectsMock = false
 
 var blockchains = []string{
 	ETH,
+	HMY,
 	XTZ,
 	Substrate,
 	ONT,
@@ -35,6 +36,8 @@ func CreateJsonManager(t subscriber.Type, sub store.Subscription) (subscriber.Js
 	switch sub.Endpoint.Type {
 	case ETH:
 		return createEthManager(t, sub), nil
+	case HMY:
+		return createHmyManager(t, sub), nil
 	case Substrate:
 		return createSubstrateManager(t, sub)
 	case BSC:
@@ -89,7 +92,7 @@ func ValidBlockchain(name string) bool {
 
 func GetValidations(t string, params Params) []int {
 	switch t {
-	case ETH:
+	case ETH, HMY:
 		return []int{
 			len(params.Addresses) + len(params.Topics),
 		}
@@ -116,7 +119,7 @@ func GetValidations(t string, params Params) []int {
 
 func CreateSubscription(sub *store.Subscription, params Params) {
 	switch sub.Endpoint.Type {
-	case ETH:
+	case ETH, HMY:
 		sub.Ethereum = store.EthSubscription{
 			Addresses: params.Addresses,
 			Topics:    params.Topics,

--- a/blockchain/hmy.go
+++ b/blockchain/hmy.go
@@ -1,0 +1,226 @@
+package blockchain
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/smartcontractkit/chainlink/core/eth"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/external-initiator/store"
+	"github.com/smartcontractkit/external-initiator/subscriber"
+)
+
+const HMY = "harmony"
+
+// The hmyManager implements the subscriber.JsonManager interface and allows
+// for interacting with HMY nodes over RPC or WS.
+type hmyManager struct {
+	fq *filterQuery
+	p  subscriber.Type
+}
+
+// createHmyManager creates a new instance of hmyManager with the provided
+// connection type and store.EthSubscription config.
+func createHmyManager(p subscriber.Type, config store.Subscription) hmyManager {
+	return hmyManager{
+		fq: createEvmFilterQuery(config.Job, config.Ethereum.Addresses),
+		p:  p,
+	}
+}
+
+// GetTriggerJson generates a JSON payload to the HMY node
+// using the config in hmyManager.
+//
+// If hmyManager is using WebSocket:
+// Creates a new "hmy_subscribe" subscription.
+//
+// If hmyManager is using RPC:
+// Sends a "hmy_getLogs" request.
+func (h hmyManager) GetTriggerJson() []byte {
+	if h.p == subscriber.RPC && h.fq.FromBlock == "" {
+		h.fq.FromBlock = "latest"
+	}
+
+	filter, err := h.fq.toMapInterface()
+	if err != nil {
+		return nil
+	}
+
+	filterBytes, err := json.Marshal(filter)
+	if err != nil {
+		return nil
+	}
+
+	msg := jsonrpcMessage{
+		Version: "2.0",
+		ID:      json.RawMessage(`1`),
+	}
+
+	switch h.p {
+	case subscriber.WS:
+		msg.Method = "hmy_subscribe"
+		msg.Params = json.RawMessage(`["logs",` + string(filterBytes) + `]`)
+	case subscriber.RPC:
+		msg.Method = "hmy_getLogs"
+		msg.Params = json.RawMessage(`[` + string(filterBytes) + `]`)
+	}
+
+	bytes, err := json.Marshal(msg)
+	if err != nil {
+		return nil
+	}
+
+	return bytes
+}
+
+// GetTestJson generates a JSON payload to test
+// the connection to the HMY node.
+//
+// If hmyManager is using WebSocket:
+// Returns nil.
+//
+// If hmyManager is using RPC:
+// Sends a request to get the latest block number.
+func (h hmyManager) GetTestJson() []byte {
+	if h.p == subscriber.RPC {
+		msg := jsonrpcMessage{
+			Version: "2.0",
+			ID:      json.RawMessage(`1`),
+			Method:  "hmy_blockNumber",
+		}
+
+		bytes, err := json.Marshal(msg)
+		if err != nil {
+			return nil
+		}
+
+		return bytes
+	}
+
+	return nil
+}
+
+// ParseTestResponse parses the response from the
+// HMY node after sending GetTestJson(), and returns
+// the error from parsing, if any.
+//
+// If hmyManager is using WebSocket:
+// Returns nil.
+//
+// If hmyManager is using RPC:
+// Attempts to parse the block number in the response.
+// If successful, stores the block number in hmyManager.
+func (h hmyManager) ParseTestResponse(data []byte) error {
+	if h.p == subscriber.RPC {
+		var msg jsonrpcMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return err
+		}
+		var res string
+		if err := json.Unmarshal(msg.Result, &res); err != nil {
+			return err
+		}
+		h.fq.FromBlock = res
+	}
+
+	return nil
+}
+
+// ParseResponse parses the response from the
+// HMY node, and returns a slice of subscriber.Events
+// and if the parsing was successful.
+//
+// If hmyManager is using RPC:
+// If there are new events, update hmyManager with
+// the latest block number it sees.
+func (e hmyManager) ParseResponse(data []byte) ([]subscriber.Event, bool) {
+	logger.Debugw("Parsing response", "ExpectsMock", ExpectsMock)
+
+	var msg jsonrpcMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		logger.Error("failed parsing msg: ", msg)
+		return nil, false
+	}
+
+	var events []subscriber.Event
+
+	switch e.p {
+	case subscriber.WS:
+		var res ethSubscribeResponse
+		if err := json.Unmarshal(msg.Params, &res); err != nil {
+			logger.Error("unmarshal:", err)
+			return nil, false
+		}
+
+		var evt eth.Log
+		if err := json.Unmarshal(res.Result, &evt); err != nil {
+			logger.Error("unmarshal:", err)
+			return nil, false
+		}
+
+		if evt.Removed {
+			return nil, false
+		}
+
+		request, err := logEventToOracleRequest(evt)
+		if err != nil {
+			logger.Error("failed to get oracle request:", err)
+			return nil, false
+		}
+
+		event, err := json.Marshal(request)
+		if err != nil {
+			logger.Error("marshal:", err)
+			return nil, false
+		}
+
+		events = append(events, event)
+
+	case subscriber.RPC:
+		var rawEvents []eth.Log
+		if err := json.Unmarshal(msg.Result, &rawEvents); err != nil {
+			logger.Error("unmarshal:", err)
+			return nil, false
+		}
+
+		for _, evt := range rawEvents {
+			if evt.Removed {
+				continue
+			}
+
+			request, err := logEventToOracleRequest(evt)
+			if err != nil {
+				logger.Error("failed to get oracle request:", err)
+				return nil, false
+			}
+
+			event, err := json.Marshal(request)
+			if err != nil {
+				logger.Error("failed marshaling request:", err)
+				continue
+			}
+			events = append(events, event)
+
+			// Check if we can update the "fromBlock" in the query,
+			// so we only get new events from blocks we haven't queried yet
+			// Increment the block number by 1, since we want events from *after* this block number
+			curBlkn := &big.Int{}
+			curBlkn = curBlkn.Add(big.NewInt(int64(evt.BlockNumber)), big.NewInt(1))
+
+			fromBlkn, err := hexutil.DecodeBig(e.fq.FromBlock)
+			if err != nil && !(e.fq.FromBlock == "latest" || e.fq.FromBlock == "") {
+				logger.Error("Failed to get block number from event:", err)
+				continue
+			}
+
+			// If our query "fromBlock" is "latest", or our current "fromBlock" is in the past compared to
+			// the last event we received, we want to update the query
+			if e.fq.FromBlock == "latest" || e.fq.FromBlock == "" || curBlkn.Cmp(fromBlkn) > 0 {
+				e.fq.FromBlock = hexutil.EncodeBig(curBlkn)
+			}
+		}
+	}
+
+	return events, true
+}

--- a/blockchain/hmy_test.go
+++ b/blockchain/hmy_test.go
@@ -1,0 +1,255 @@
+package blockchain
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/external-initiator/store"
+	"github.com/smartcontractkit/external-initiator/subscriber"
+)
+
+func TestCreateHmyFilterMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		args store.EthSubscription
+		p    subscriber.Type
+		want []byte
+	}{
+		{
+			"empty",
+			store.EthSubscription{},
+			subscriber.WS,
+			[]byte(`{"jsonrpc":"2.0","id":1,"method":"hmy_subscribe","params":["logs",{"address":null,"fromBlock":"0x0","toBlock":"latest","topics":[["0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65"],["0x0000000000000000000000000000000000000000000000000000000000000000"]]}]}`),
+		},
+		{
+			"address only",
+			store.EthSubscription{Addresses: []string{"0x049Bd8C3adC3fE7d3Fc2a44541d955A537c2A484"}},
+			subscriber.WS,
+			[]byte(`{"jsonrpc":"2.0","id":1,"method":"hmy_subscribe","params":["logs",{"address":["0x049bd8c3adc3fe7d3fc2a44541d955a537c2a484"],"fromBlock":"0x0","toBlock":"latest","topics":[["0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65"],["0x0000000000000000000000000000000000000000000000000000000000000000"]]}]}`),
+		},
+		{
+			"empty RPC",
+			store.EthSubscription{},
+			subscriber.RPC,
+			[]byte(`{"jsonrpc":"2.0","id":1,"method":"hmy_getLogs","params":[{"address":null,"fromBlock":"latest","toBlock":"latest","topics":[["0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65"],["0x0000000000000000000000000000000000000000000000000000000000000000"]]}]}`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createHmyManager(tt.p, store.Subscription{Ethereum: tt.args}).GetTriggerJson(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetTriggerJson() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("has invalid filter query", func(t *testing.T) {
+		blockHash := common.HexToHash("0xabc")
+		got := hmyManager{fq: &filterQuery{BlockHash: &blockHash, FromBlock: "0x1", ToBlock: "0x2"}}.GetTriggerJson()
+		if got != nil {
+			t.Errorf("GetTriggerJson() = %s, want nil", got)
+		}
+	})
+}
+
+func TestHmyManager_GetTestJson(t *testing.T) {
+	type fields struct {
+		fq *filterQuery
+		p  subscriber.Type
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []byte
+	}{
+		{
+			"returns JSON when using RPC",
+			fields{
+				p: subscriber.RPC,
+			},
+			[]byte(`{"jsonrpc":"2.0","id":1,"method":"hmy_blockNumber"}`),
+		},
+		{
+			"returns empty when using WS",
+			fields{
+				p: subscriber.WS,
+			},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := hmyManager{
+				fq: tt.fields.fq,
+				p:  tt.fields.p,
+			}
+			if got := e.GetTestJson(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetTestJson() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHmyManager_ParseTestResponse(t *testing.T) {
+	type fields struct {
+		fq *filterQuery
+		p  subscriber.Type
+	}
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name              string
+		fields            fields
+		args              args
+		wantErr           bool
+		expectedFromBlock string
+	}{
+		{
+			"does nothing for WS",
+			fields{fq: &filterQuery{}, p: subscriber.WS},
+			args{},
+			false,
+			"",
+		},
+		{
+			"parses RPC responses",
+			fields{fq: &filterQuery{}, p: subscriber.RPC},
+			args{[]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`)},
+			false,
+			"0x1",
+		},
+		{
+			"fails unmarshal payload",
+			fields{fq: &filterQuery{}, p: subscriber.RPC},
+			args{[]byte(`error`)},
+			true,
+			"",
+		},
+		{
+			"fails unmarshal result",
+			fields{fq: &filterQuery{}, p: subscriber.RPC},
+			args{[]byte(`{"jsonrpc":"2.0","id":1,"result":["0x1"]}`)},
+			true,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := hmyManager{
+				fq: tt.fields.fq,
+				p:  tt.fields.p,
+			}
+			if err := e.ParseTestResponse(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("ParseTestResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if e.fq.FromBlock != tt.expectedFromBlock {
+				t.Errorf("FromBlock = %s, expected %s", e.fq.FromBlock, tt.expectedFromBlock)
+			}
+		})
+	}
+}
+
+func TestHmyManager_ParseResponse(t *testing.T) {
+	type manager struct {
+		fq *filterQuery
+		p  subscriber.Type
+	}
+	type fields struct {
+		manager
+	}
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name              string
+		fields            fields
+		args              args
+		want              []subscriber.Event
+		want1             bool
+		expectedFromBlock string
+	}{
+		{
+			"fails parsing invalid payload",
+			fields{manager{fq: &filterQuery{}, p: subscriber.WS}},
+			args{data: []byte(`invalid`)},
+			nil,
+			false,
+			"",
+		},
+		{
+			"fails parsing invalid WS subscribe payload",
+			fields{manager{fq: &filterQuery{}, p: subscriber.WS}},
+			args{data: []byte(`{"jsonrpc":"2.0","id":1,"params":[]}`)},
+			nil,
+			false,
+			"",
+		},
+		{
+			"fails parsing invalid WS subscribe",
+			fields{manager{fq: &filterQuery{}, p: subscriber.WS}},
+			args{data: []byte(`{"jsonrpc":"2.0","id":1,"params":{"subscription":"test","result":[]}}`)},
+			nil,
+			false,
+			"",
+		},
+		{
+			"successfully parses WS Oracle request",
+			fields{manager{fq: &filterQuery{}, p: subscriber.WS}},
+			args{data: []byte(`{"jsonrpc":"2.0","id":1,"params":{"subscription":"test","result":{"data":"0x0000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000005663676574783f68747470733a2f2f6d696e2d6170692e63727970746f636f6d706172652e636f6d2f646174612f70726963653f6673796d3d455448267473796d733d5553446470617468635553446574696d65731864","address":"0xFadfF79bA04F169386646a43869B66B39c7E0858","logIndex":"0x0","blockNumber":"0x2","blockHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","topics":["0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65","0x0000000000000000000000000000000000000000000000000000000000000000"]}}}`)},
+			[]subscriber.Event{subscriber.Event(`{"address":"0xFadfF79bA04F169386646a43869B66B39c7E0858","dataPrefix":"0x354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b","functionSelector":"0x4ab0d190","get":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD","path":"USD","times":100}`)},
+			true,
+			"",
+		},
+		{
+			"fails parsing invalid RPC payload",
+			fields{manager{fq: &filterQuery{}, p: subscriber.RPC}},
+			args{data: []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)},
+			nil,
+			false,
+			"",
+		},
+		{
+			"fails parsing invalid block number in RPC event payload",
+			fields{manager{fq: &filterQuery{}, p: subscriber.RPC}},
+			args{data: []byte(`{"jsonrpc":"2.0","id":1,"result":[{"data":"0x0000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000005663676574783f68747470733a2f2f6d696e2d6170692e63727970746f636f6d706172652e636f6d2f646174612f70726963653f6673796d3d455448267473796d733d5553446470617468635553446574696d65731864","address":"0xFadfF79bA04F169386646a43869B66B39c7E0858","logIndex":"0x0","blockNumber":"abc","blockHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","topics":["0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65","0x0000000000000000000000000000000000000000000000000000000000000000"]}]}`)},
+			nil,
+			false,
+			"",
+		},
+		{
+			"updates fromBlock from RPC payload",
+			fields{manager{fq: &filterQuery{}, p: subscriber.RPC}},
+			args{data: []byte(`{"jsonrpc":"2.0","id":1,"result":[{"data":"0x0000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000005663676574783f68747470733a2f2f6d696e2d6170692e63727970746f636f6d706172652e636f6d2f646174612f70726963653f6673796d3d455448267473796d733d5553446470617468635553446574696d65731864","address":"0xFadfF79bA04F169386646a43869B66B39c7E0858","logIndex":"0x0","blockNumber":"0x3","blockHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","topics":["0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65","0x0000000000000000000000000000000000000000000000000000000000000000"]}]}`)},
+			[]subscriber.Event{subscriber.Event(`{"address":"0xFadfF79bA04F169386646a43869B66B39c7E0858","dataPrefix":"0x354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b","functionSelector":"0x4ab0d190","get":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD","path":"USD","times":100}`)},
+			true,
+			"0x4",
+		},
+		{
+			"does not update fromBlock in the past from RPC payload",
+			fields{manager{fq: &filterQuery{FromBlock: "0x1"}, p: subscriber.RPC}},
+			args{data: []byte(`{"jsonrpc":"2.0","id":1,"result":[{"data":"0x0000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000005663676574783f68747470733a2f2f6d696e2d6170692e63727970746f636f6d706172652e636f6d2f646174612f70726963653f6673796d3d455448267473796d733d5553446470617468635553446574696d65731864","address":"0xFadfF79bA04F169386646a43869B66B39c7E0858","logIndex":"0x0","blockNumber":"0x0","blockHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xabc0000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0","topics":["0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65","0x0000000000000000000000000000000000000000000000000000000000000000"]}]}`)},
+			[]subscriber.Event{subscriber.Event(`{"address":"0xFadfF79bA04F169386646a43869B66B39c7E0858","dataPrefix":"0x354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b","functionSelector":"0x4ab0d190","get":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD","path":"USD","times":100}`)},
+			true,
+			"0x1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := hmyManager{
+				fq: tt.fields.fq,
+				p:  tt.fields.p,
+			}
+			got, got1 := e.ParseResponse(tt.args.data)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseResponse() got = %s, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ParseResponse() got1 = %v, want %v", got1, tt.want1)
+			}
+			if e.fq.FromBlock != tt.expectedFromBlock {
+				t.Errorf("FromBlock = %s, expected %s", e.fq.FromBlock, tt.expectedFromBlock)
+			}
+		})
+	}
+}

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -63,6 +63,8 @@ services:
     command:
       - '{"name":"eth-mock-http","type":"ethereum","url":"http://mock:8080/rpc/eth","refreshInterval":600}'
       - '{"name":"eth-mock-ws","type":"ethereum","url":"ws://mock:8080/ws/eth"}'
+      - '{"name":"hmy-mock-http","type":"harmony","url":"http://mock:8080/rpc/hmy","refreshInterval":600}'
+      - '{"name":"hmy-mock-ws","type":"harmony","url":"ws://mock:8080/ws/hmy"}'
       - '{"name":"xtz-mock-http","type":"tezos","url":"http://mock:8080/http/xtz"}'
       - '{"name":"ont-mock-http","type":"ontology","url":"http://mock:8080/rpc/ont"}'
       - '{"name":"substrate-mock-ws","type":"substrate","url":"ws://mock:8080/ws/substrate"}'

--- a/integration/mock-client/blockchain/common.go
+++ b/integration/mock-client/blockchain/common.go
@@ -25,6 +25,8 @@ func HandleRequest(conn, platform string, msg JsonrpcMessage) ([]JsonrpcMessage,
 	switch platform {
 	case "eth":
 		return handleEthRequest(conn, msg)
+	case "hmy":
+		return handleHmyRequest(conn, msg)
 	case "ont":
 		return handleOntRequest(msg)
 	case "binance-smart-chain":

--- a/integration/mock-client/blockchain/harmony.go
+++ b/integration/mock-client/blockchain/harmony.go
@@ -1,0 +1,208 @@
+package blockchain
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func handleHmyRequest(conn string, msg JsonrpcMessage) ([]JsonrpcMessage, error) {
+	if conn == "ws" {
+		switch msg.Method {
+		case "hmy_subscribe":
+			return handleHmySubscribe(msg)
+		}
+	} else {
+		switch msg.Method {
+		case "hmy_getLogs":
+			return handleHmyGetLogs(msg)
+		}
+	}
+
+	return nil, fmt.Errorf("unexpected method: %v", msg.Method)
+}
+
+type hmySubscribeResponse struct {
+	Subscription string          `json:"subscription"`
+	Result       json.RawMessage `json:"result"`
+}
+
+func handleHmyMapStringInterface(in map[string]json.RawMessage) (hmyLogResponse, error) {
+	topics, err := getHmyTopicsFromMap(in)
+	if err != nil {
+		return hmyLogResponse{}, err
+	}
+
+	var topicsStr []string
+	if len(topics) > 0 {
+		for _, t := range topics[0] {
+			topicsStr = append(topicsStr, t.String())
+		}
+	}
+
+	addresses, err := getHmyAddressesFromMap(in)
+	if err != nil {
+		return hmyLogResponse{}, err
+	}
+
+	return hmyLogResponse{
+		LogIndex:         "0x0",
+		BlockNumber:      "0x2",
+		BlockHash:        "0xabc0000000000000000000000000000000000000000000000000000000000000",
+		TransactionHash:  "0xabc0000000000000000000000000000000000000000000000000000000000000",
+		TransactionIndex: "0x0",
+		Address:          addresses[0].String(),
+		Data:             "0x0000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000005663676574783f68747470733a2f2f6d696e2d6170692e63727970746f636f6d706172652e636f6d2f646174612f70726963653f6673796d3d455448267473796d733d5553446470617468635553446574696d65731864",
+		Topics:           topicsStr,
+	}, nil
+}
+
+func handleHmySubscribe(msg JsonrpcMessage) ([]JsonrpcMessage, error) {
+	var contents []json.RawMessage
+	err := json.Unmarshal(msg.Params, &contents)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(contents) != 2 {
+		return nil, fmt.Errorf("possibly incorrect length of params array: %v", len(contents))
+	}
+
+	var filter map[string]json.RawMessage
+	err = json.Unmarshal(contents[1], &filter)
+	if err != nil {
+		return nil, err
+	}
+
+	log, err := handleHmyMapStringInterface(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	logBz, err := json.Marshal(log)
+	if err != nil {
+		return nil, err
+	}
+
+	subResp := hmySubscribeResponse{
+		Subscription: "test",
+		Result:       logBz,
+	}
+
+	subBz, err := json.Marshal(subResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return []JsonrpcMessage{
+		// Send a confirmation message first
+		// This is currently ignored, so don't fill
+		{
+			Version: "2.0",
+			ID:      msg.ID,
+			Method:  "hmy_subscribe",
+		},
+		{
+			Version: "2.0",
+			ID:      msg.ID,
+			Method:  "hmy_subscribe",
+			Params:  subBz,
+		},
+	}, nil
+}
+
+type hmyLogResponse struct {
+	LogIndex         string   `json:"logIndex"`
+	BlockNumber      string   `json:"blockNumber"`
+	BlockHash        string   `json:"blockHash"`
+	TransactionHash  string   `json:"transactionHash"`
+	TransactionIndex string   `json:"transactionIndex"`
+	Address          string   `json:"address"`
+	Data             string   `json:"data"`
+	Topics           []string `json:"topics"`
+}
+
+func getHmyTopicsFromMap(req map[string]json.RawMessage) ([][]common.Hash, error) {
+	topicsInterface, ok := req["topics"]
+	if !ok {
+		return nil, errors.New("no topics included")
+	}
+
+	var topicsArr []*[]string
+	err := json.Unmarshal(topicsInterface, &topicsArr)
+	if err != nil {
+		return nil, err
+	}
+
+	var finalTopics [][]common.Hash
+	for _, t := range topicsArr {
+		if t == nil {
+			continue
+		}
+
+		topics := make([]common.Hash, len(*t))
+		for i, s := range *t {
+			topics[i] = common.HexToHash(s)
+		}
+
+		finalTopics = append(finalTopics, topics)
+	}
+
+	return finalTopics, nil
+}
+
+func getHmyAddressesFromMap(req map[string]json.RawMessage) ([]common.Address, error) {
+	addressesInterface, ok := req["address"]
+	if !ok {
+		return nil, errors.New("no addresses included")
+	}
+
+	var addresses []common.Address
+	err := json.Unmarshal(addressesInterface, &addresses)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(addresses) < 1 {
+		return nil, errors.New("no addresses provided")
+	}
+
+	return addresses, nil
+}
+
+func hmyLogRequestToResponse(msg JsonrpcMessage) (hmyLogResponse, error) {
+	var reqs []map[string]json.RawMessage
+	err := json.Unmarshal(msg.Params, &reqs)
+	if err != nil {
+		return hmyLogResponse{}, err
+	}
+
+	if len(reqs) != 1 {
+		return hmyLogResponse{}, fmt.Errorf("expected exactly 1 filter in request, got %d", len(reqs))
+	}
+
+	return handleHmyMapStringInterface(reqs[0])
+}
+
+func handleHmyGetLogs(msg JsonrpcMessage) ([]JsonrpcMessage, error) {
+	log, err := hmyLogRequestToResponse(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	logs := []hmyLogResponse{log}
+	data, err := json.Marshal(logs)
+	if err != nil {
+		return nil, err
+	}
+
+	return []JsonrpcMessage{
+		{
+			Version: "2.0",
+			ID:      msg.ID,
+			Result:  data,
+		},
+	}, nil
+}

--- a/integration/mock-client/blockchain/harmony_test.go
+++ b/integration/mock-client/blockchain/harmony_test.go
@@ -1,0 +1,554 @@
+package blockchain
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func getHmyLogResponse(address string, topics []string) hmyLogResponse {
+	return hmyLogResponse{
+		LogIndex:         "0x0",
+		BlockNumber:      "0x2",
+		BlockHash:        "0xabc0000000000000000000000000000000000000000000000000000000000000",
+		TransactionHash:  "0xabc0000000000000000000000000000000000000000000000000000000000000",
+		TransactionIndex: "0x0",
+		Address:          address,
+		Data:             "0x0000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb354f99e2ac319d0d1ff8975c41c72bf347fb69a4874e2641bd19c32e09eb88b80000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000007d0965224facd7156df0c9a1adf3a94118026eeb92cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005ef1cd6b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000005663676574783f68747470733a2f2f6d696e2d6170692e63727970746f636f6d706172652e636f6d2f646174612f70726963653f6673796d3d455448267473796d733d5553446470617468635553446574696d65731864",
+		Topics:           topics,
+	}
+}
+
+func hmyInterfaceToJson(in interface{}) json.RawMessage {
+	bz, _ := json.Marshal(in)
+	return bz
+}
+
+var hmyAddress = common.HexToAddress("0x0")
+var hmyAddress2 = common.HexToAddress("0x1")
+var hmyHash = common.HexToHash("0x123")
+
+func Test_hmyLogRequestToResponse(t *testing.T) {
+	type args struct {
+		msg JsonrpcMessage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    hmyLogResponse
+		wantErr bool
+	}{
+		{
+			"correct hmy_log request",
+			args{
+				JsonrpcMessage{
+					Params: json.RawMessage(fmt.Sprintf(`[{"topics":[["%s"]],"address":["%s"]}]`, hash.String(), address.String())),
+				},
+			},
+			getHmyLogResponse(address.String(), []string{hash.String()}),
+			false,
+		},
+		{
+			"hmy_log request with empty topics",
+			args{
+				JsonrpcMessage{
+					Params: json.RawMessage(fmt.Sprintf(`[{"topics":[null],"address":["%s"]}]`, address.String())),
+				},
+			},
+			getHmyLogResponse(address.String(), nil),
+			false,
+		},
+		{
+			"misformed payload",
+			args{
+				JsonrpcMessage{
+					Params: json.RawMessage(`[{"topics":[null],"address":"0x0"}]`),
+				},
+			},
+			hmyLogResponse{},
+			true,
+		},
+		{
+			"empty request",
+			args{
+				JsonrpcMessage{
+					Params: json.RawMessage(`[]`),
+				},
+			},
+			hmyLogResponse{},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hmyLogRequestToResponse(tt.args.msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hmyLogRequestToResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("hmyLogRequestToResponse() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getHmyAddressesFromMap(t *testing.T) {
+	type args struct {
+		req map[string]json.RawMessage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []common.Address
+		wantErr bool
+	}{
+		{
+			"correct payload",
+			args{
+				map[string]json.RawMessage{
+					"address": json.RawMessage(fmt.Sprintf(`["%s"]`, hmyAddress.String())),
+				},
+			},
+			[]common.Address{address},
+			false,
+		},
+		{
+			"multiple addresses",
+			args{
+				map[string]json.RawMessage{
+					"address": json.RawMessage(fmt.Sprintf(`["%s", "%s", "%s"]`, hmyAddress.String(), hmyAddress.String(), hmyAddress.String())),
+				},
+			},
+			[]common.Address{address, address, address},
+			false,
+		},
+		{
+			"no addresses",
+			args{
+				map[string]json.RawMessage{
+					"address": json.RawMessage(`[]`),
+				},
+			},
+			nil,
+			true,
+		},
+		{
+			"missing address key",
+			args{
+				map[string]json.RawMessage{
+					"something_else": json.RawMessage(fmt.Sprintf(`["%s"]`, hmyAddress.String())),
+				},
+			},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getHmyAddressesFromMap(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAddressesFromMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAddressesFromMap() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getHmyTopicsFromMap(t *testing.T) {
+	type args struct {
+		req map[string]json.RawMessage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    [][]common.Hash
+		wantErr bool
+	}{
+		{
+			"correct payload",
+			args{
+				map[string]json.RawMessage{
+					"topics": json.RawMessage(fmt.Sprintf(`[["%s"]]`, hmyHash.String())),
+				},
+			},
+			[][]common.Hash{{hmyHash}},
+			false,
+		},
+		{
+			"multiple topics",
+			args{
+				map[string]json.RawMessage{
+					"topics": json.RawMessage(fmt.Sprintf(`[["%s","%s"],["%s"]]`, hmyHash.String(), hmyHash.String(), hmyHash.String())),
+				},
+			},
+			[][]common.Hash{{hmyHash, hmyHash}, {hmyHash}},
+			false,
+		},
+		{
+			"nil in topics",
+			args{
+				map[string]json.RawMessage{
+					"topics": json.RawMessage(fmt.Sprintf(`[null,["%s"]]`, hmyHash.String())),
+				},
+			},
+			[][]common.Hash{{hmyHash}},
+			false,
+		},
+		{
+			"nil topics",
+			args{
+				map[string]json.RawMessage{
+					"topics": json.RawMessage(`[null]`),
+				},
+			},
+			nil,
+			false,
+		},
+		{
+			"missing topics key",
+			args{
+				map[string]json.RawMessage{
+					"something_else": json.RawMessage(`[null]`),
+				},
+			},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getHmyTopicsFromMap(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getHmyTopicsFromMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getHmyTopicsFromMap() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleHmyBlockNumber(t *testing.T) {
+	type args struct {
+		msg JsonrpcMessage
+	}
+	tests := []struct {
+		name   string
+		args   args
+		want   []JsonrpcMessage
+		wantOk bool
+	}{
+		{
+			"returns a block number with the correct ID",
+			args{
+				JsonrpcMessage{ID: []byte(`123`), Method: "hmy_blockNumber"},
+			},
+			[]JsonrpcMessage{
+				{
+					Version: "2.0",
+					ID:      []byte(`123`),
+					Result:  []byte(`"0x0"`),
+				},
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := GetCannedResponse("hmy", tt.args.msg)
+			if ok != tt.wantOk {
+				t.Errorf("handleHmyBlockNumber() ok = %v, wantOk %v", ok, tt.wantOk)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleHmyBlockNumber() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleHmyGetLogs(t *testing.T) {
+	type args struct {
+		msg JsonrpcMessage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []JsonrpcMessage
+		wantErr bool
+	}{
+		{
+			"returns a response with the correct ID",
+			args{
+				JsonrpcMessage{
+					ID:     []byte(`123`),
+					Params: json.RawMessage(fmt.Sprintf(`[{"topics":[["%s"]],"address":["%s"]}]`, hash.String(), address.String())),
+				},
+			},
+			[]JsonrpcMessage{
+				{
+					Version: "2.0",
+					ID:      []byte(`123`),
+					Result:  hmyInterfaceToJson([]hmyLogResponse{getHmyLogResponse(address.String(), []string{hash.String()})}),
+				},
+			},
+			false,
+		},
+		{
+			"fails on missing address",
+			args{
+				JsonrpcMessage{
+					ID:     []byte(`123`),
+					Params: json.RawMessage(fmt.Sprintf(`[{"topics":[["%s"]],"address":[]}]`, hash.String())),
+				},
+			},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleHmyGetLogs(tt.args.msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleHmyGetLogs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleHmyGetLogs() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleHmyRequest(t *testing.T) {
+	type args struct {
+		conn string
+		msg  JsonrpcMessage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []JsonrpcMessage
+		wantErr bool
+	}{
+		{
+			"handles WS subscribe",
+			args{
+				"ws",
+				JsonrpcMessage{
+					Method: "hmy_subscribe",
+					Params: json.RawMessage(fmt.Sprintf(`["logs",{"topics":[null],"address":["%s"]}]`, hmyAddress.String())),
+				},
+			},
+			[]JsonrpcMessage{
+				{
+					Version: "2.0",
+					Method:  "hmy_subscribe",
+				},
+				{
+					Version: "2.0",
+					Method:  "hmy_subscribe",
+					Params:  json.RawMessage(fmt.Sprintf(`{"subscription":"test","result":%s}`, hmyInterfaceToJson(getHmyLogResponse(hmyAddress.String(), nil)))),
+				},
+			},
+			false,
+		},
+		{
+			"fails hmy_subscribe on RPC",
+			args{
+				"rpc",
+				JsonrpcMessage{
+					Method: "hmy_subscribe",
+					Params: json.RawMessage(fmt.Sprintf(`["logs",{"topics":[null],"address":["%s"]}]`, hmyAddress.String())),
+				},
+			},
+			nil,
+			true,
+		},
+		{
+			"gets logs",
+			args{
+				"rpc",
+				JsonrpcMessage{
+					Method: "hmy_getLogs",
+					Params: json.RawMessage(fmt.Sprintf(`[{"topics":[["%s"]],"address":["%s"]}]`, hmyHash.String(), hmyAddress.String())),
+				},
+			},
+			[]JsonrpcMessage{
+				{
+					Version: "2.0",
+					Result:  hmyInterfaceToJson([]hmyLogResponse{getHmyLogResponse(hmyAddress.String(), []string{hmyHash.String()})}),
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleHmyRequest(tt.args.conn, tt.args.msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleHmyRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleHmyRequest() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleHmySubscribe(t *testing.T) {
+	type args struct {
+		msg JsonrpcMessage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []JsonrpcMessage
+		wantErr bool
+	}{
+		{
+			"handles correct subscribe",
+			args{
+				JsonrpcMessage{
+					Method: "hmy_subscribe",
+					Params: json.RawMessage(fmt.Sprintf(`["logs",{"topics":[null],"address":["%s"]}]`, hmyAddress.String())),
+				},
+			},
+			[]JsonrpcMessage{
+				{
+					Version: "2.0",
+					Method:  "hmy_subscribe",
+				},
+				{
+					Version: "2.0",
+					Method:  "hmy_subscribe",
+					Params:  json.RawMessage(fmt.Sprintf(`{"subscription":"test","result":%s}`, hmyInterfaceToJson(getHmyLogResponse(hmyAddress.String(), nil)))),
+				},
+			},
+			false,
+		},
+		{
+			"incorrect params array",
+			args{
+				JsonrpcMessage{
+					Method: "hmy_subscribe",
+					Params: json.RawMessage(fmt.Sprintf(`[{"topics":[null],"address":["%s"]}]`, hmyAddress.String())),
+				},
+			},
+			nil,
+			true,
+		},
+		{
+			"incorrect map string interface",
+			args{
+				JsonrpcMessage{
+					Method: "hmy_subscribe",
+					Params: json.RawMessage(fmt.Sprintf(`["logs",{"address":["%s"]}]`, hmyAddress.String())),
+				},
+			},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleHmySubscribe(tt.args.msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleHmySubscribe() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleHmySubscribe() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleHmyMapStringInterface(t *testing.T) {
+	type args struct {
+		in map[string]json.RawMessage
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    hmyLogResponse
+		wantErr bool
+	}{
+		{
+			"correct hmy_log request",
+			args{
+				map[string]json.RawMessage{
+					"topics":  json.RawMessage(fmt.Sprintf(`[["%s"]]`, hmyHash.String())),
+					"address": json.RawMessage(fmt.Sprintf(`["%s"]`, hmyAddress.String())),
+				},
+			},
+			getHmyLogResponse(hmyAddress.String(), []string{hmyHash.String()}),
+			false,
+		},
+		{
+			"hmy_log request with empty topics",
+			args{
+				map[string]json.RawMessage{
+					"topics":  json.RawMessage(`[]`),
+					"address": json.RawMessage(fmt.Sprintf(`["%s"]`, hmyAddress.String())),
+				},
+			},
+			getHmyLogResponse(hmyAddress.String(), nil),
+			false,
+		},
+		{
+			"hmy_log request with no topics",
+			args{
+				map[string]json.RawMessage{
+					"address": json.RawMessage(fmt.Sprintf(`["%s"]`, hmyAddress.String())),
+				},
+			},
+			hmyLogResponse{},
+			true,
+		},
+		{
+			"uses first address",
+			args{
+				map[string]json.RawMessage{
+					"topics":  json.RawMessage(fmt.Sprintf(`[["%s"]]`, hmyHash.String())),
+					"address": json.RawMessage(fmt.Sprintf(`["%s", "%s"]`, hmyAddress.String(), hmyAddress2.String())),
+				},
+			},
+			getHmyLogResponse(hmyAddress.String(), []string{hmyHash.String()}),
+			false,
+		},
+		{
+			"fails on no addresses",
+			args{
+				map[string]json.RawMessage{
+					"topics":  json.RawMessage(fmt.Sprintf(`[["%s"]]`, hash.String())),
+					"address": json.RawMessage(`[]`),
+				},
+			},
+			hmyLogResponse{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleHmyMapStringInterface(tt.args.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleHmyMapStringInterface() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleHmyMapStringInterface() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/integration/mock-client/blockchain/mock-responses/hmy.json
+++ b/integration/mock-client/blockchain/mock-responses/hmy.json
@@ -1,0 +1,8 @@
+{
+  "hmy_blockNumber": [
+    {
+      "jsonrpc": "2.0",
+      "result": "0x0"
+    }
+  ]
+}

--- a/integration/run_test
+++ b/integration/run_test
@@ -25,6 +25,8 @@ run_test() {
 
   ./integration/test_ei_event "eth-mock-http"
   ./integration/test_ei_event "eth-mock-ws"
+  ./integration/test_ei_event "hmy-mock-http"
+  ./integration/test_ei_event "hmy-mock-ws"
   ./integration/test_ei_event "xtz-mock-http"
   ./integration/test_ei_event "ont-mock-http"
   ./integration/test_ei_event "bsc-mock-http"


### PR DESCRIPTION
This PR adds support for harmony blockchain initiator for listening to blockchain events. Our subscription is exactly same as eths with only difference in the methods, instead of `eth_getLogs`, we have `hmy_getLogs`. Same for `eth_subscribe`, we have `hmy_subscribe`. 

Tested the code by connecting to our testnet ws endpoint, where I could get the event received in the initiator for a specific contract address. 