### PR TITLE
Add Prometheus metrics export

### DIFF
--- a/blockchain/cfx.go
+++ b/blockchain/cfx.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/external-initiator/store"
@@ -19,8 +20,10 @@ const CFX = "conflux"
 // The cfxManager implements the subscriber.JsonManager interface and allows
 // for interacting with CFX nodes over RPC.
 type cfxManager struct {
-	fq *cfxFilterQuery
-	p  subscriber.Type
+	fq           *cfxFilterQuery
+	p            subscriber.Type
+	endpointName string
+	jobid        string
 }
 
 // createCfxManager creates a new instance of cfxManager with the provided
@@ -44,7 +47,9 @@ func createCfxManager(p subscriber.Type, config store.Subscription) cfxManager {
 			Addresses: addresses,
 			Topics:    topics,
 		},
-		p: p,
+		p:            p,
+		endpointName: config.EndpointName,
+		jobid:        config.Job,
 	}
 }
 
@@ -190,6 +195,7 @@ func Cfx2EthResponse(cfx cfxLogResponse) (models.Log, error) {
 // If there are new events, update cfxManager with
 // the latest block number it sees.
 func (e cfxManager) ParseResponse(data []byte) ([]subscriber.Event, bool) {
+	promLastSourcePing.With(prometheus.Labels{"endpoint": e.endpointName, "jobid": e.jobid}).SetToCurrentTime()
 	logger.Debugw("Parsing response", "ExpectsMock", ExpectsMock)
 
 	var msg JsonrpcMessage

--- a/blockchain/common.go
+++ b/blockchain/common.go
@@ -12,6 +12,16 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/external-initiator/store"
 	"github.com/smartcontractkit/external-initiator/subscriber"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	promLastSourcePing = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ei_last_source_ping",
+		Help: "The timestamp of the last source of life from the source",
+	}, []string{"endpoint", "jobid"})
 )
 
 var (

--- a/blockchain/eth.go
+++ b/blockchain/eth.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/external-initiator/store"
 	"github.com/smartcontractkit/external-initiator/subscriber"
@@ -16,8 +17,10 @@ const ETH = "ethereum"
 // The ethManager implements the subscriber.JsonManager interface and allows
 // for interacting with ETH nodes over RPC or WS.
 type ethManager struct {
-	fq *filterQuery
-	p  subscriber.Type
+	fq           *filterQuery
+	p            subscriber.Type
+	endpointName string
+	jobid        string
 }
 
 // createEthManager creates a new instance of ethManager with the provided
@@ -43,7 +46,9 @@ func createEthManager(p subscriber.Type, config store.Subscription) ethManager {
 			Addresses: addresses,
 			Topics:    topics,
 		},
-		p: p,
+		p:            p,
+		endpointName: config.EndpointName,
+		jobid:        config.Job,
 	}
 }
 
@@ -172,6 +177,7 @@ type ethLogResponse struct {
 // If there are new events, update ethManager with
 // the latest block number it sees.
 func (e ethManager) ParseResponse(data []byte) ([]subscriber.Event, bool) {
+	promLastSourcePing.With(prometheus.Labels{"endpoint": e.endpointName, "jobid": e.jobid}).SetToCurrentTime()
 	logger.Debugw("Parsing response", "ExpectsMock", ExpectsMock)
 
 	var msg JsonrpcMessage

--- a/blockchain/near.go
+++ b/blockchain/near.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/external-initiator/store"
 	"github.com/smartcontractkit/external-initiator/subscriber"
@@ -118,6 +119,7 @@ type nearFilter struct {
 type nearManager struct {
 	filter         *nearFilter
 	connectionType subscriber.Type
+	endpointName   string
 }
 
 // createNearManager creates a new instance of nearManager with the provided
@@ -134,6 +136,7 @@ func createNearManager(connectionType subscriber.Type, config store.Subscription
 			Nonces:     nil,
 		},
 		connectionType: connectionType,
+		endpointName:   config.EndpointName,
 	}, nil
 }
 
@@ -194,6 +197,7 @@ func (m nearManager) GetTriggerJson() []byte {
 
 // ParseResponse generates []subscriber.Event from JSON-RPC response, requested using the GetTriggerJson message
 func (m nearManager) ParseResponse(data []byte) ([]subscriber.Event, bool) {
+	promLastSourcePing.With(prometheus.Labels{"endpoint": m.endpointName, "jobid": m.filter.JobID}).SetToCurrentTime()
 	logger.Debugw("Parsing NEAR response", "ExpectsMock", ExpectsMock)
 
 	var msg JsonrpcMessage

--- a/client/web.go
+++ b/client/web.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Depado/ginprom"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -16,6 +17,8 @@ import (
 	"github.com/smartcontractkit/external-initiator/blockchain"
 	"github.com/smartcontractkit/external-initiator/store"
 )
+
+var ginPrometheus *ginprom.Prometheus
 
 const (
 	externalInitiatorAccessKeyHeader = "X-Chainlink-EA-AccessKey"
@@ -27,6 +30,18 @@ type subscriptionStorer interface {
 	DeleteJob(jobid string) error
 	GetEndpoint(name string) (*store.Endpoint, error)
 	SaveEndpoint(endpoint *store.Endpoint) error
+}
+
+func init() {
+	gin.DebugPrintRouteFunc = printRoutes
+
+	// ensure metrics are regsitered once per instance to avoid registering
+	// metrics multiple times (panic)
+	ginPrometheus = ginprom.New(ginprom.Namespace("service"))
+}
+
+func printRoutes(httpMethod, absolutePath, handlerName string, nuHandlers int) {
+	logger.Debugf("%-6s %-25s --> %s (%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
 }
 
 // RunWebserver starts a new web server using the access key
@@ -75,12 +90,18 @@ func (srv *HttpService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (srv *HttpService) createRouter() {
-	r := gin.New()
-	r.Use(gin.Recovery())
-	r.Use(loggerFunc())
-	r.GET("/health", srv.ShowHealth)
+	engine := gin.New()
 
-	auth := r.Group("/")
+	ginPrometheus.Use(engine)
+	engine.Use(
+		gin.Recovery(),
+		loggerFunc(),
+		ginPrometheus.Instrument(),
+	)
+
+	engine.GET("/health", srv.ShowHealth)
+
+	auth := engine.Group("/")
 	auth.Use(authenticate(srv.AccessKey, srv.Secret))
 	{
 		auth.POST("/jobs", srv.CreateSubscription)
@@ -88,7 +109,7 @@ func (srv *HttpService) createRouter() {
 		auth.POST("/config", srv.CreateEndpoint)
 	}
 
-	srv.Router = r
+	srv.Router = engine
 }
 
 func authenticate(accessKey, secret string) gin.HandlerFunc {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/smartcontractkit/external-initiator
 go 1.15
 
 require (
+	github.com/Depado/ginprom v1.2.1-0.20200115153638-53bbba851bd8
 	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
 	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
@@ -21,6 +22,7 @@ require (
 	github.com/ontio/ontology-go-sdk v1.11.1
 	github.com/pierrec/xxHash v0.1.5 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.8.0
 	github.com/smartcontractkit/chainlink v0.9.5-0.20201214122441-66aaea171293
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1


### PR DESCRIPTION
Example of exported metrics:

```
# HELP ei_jobruns_success The number of successful jobruns
# TYPE ei_jobruns_success counter
ei_jobruns_success{jobid="031bc83b1b9c479492af4a1dffa94a1b"} 8
ei_jobruns_success{jobid="0d0008301a574ad39638ccd6161de88c"} 3
ei_jobruns_success{jobid="0e5d60fa91ca461ca4dd719979c922b5"} 8
ei_jobruns_success{jobid="283e8552b6da44ea82808f4bf99a914e"} 1
ei_jobruns_success{jobid="2f334446d386489b844bc3b3ead3cf89"} 1
ei_jobruns_success{jobid="3007917f8f674fc08ad09a043a4d56c5"} 1
ei_jobruns_success{jobid="3397fdd971804484b279aa425006ab7b"} 1
ei_jobruns_success{jobid="451907c98fc7409fbbf5f3fa167e00cd"} 8
ei_jobruns_success{jobid="5f36cad8352b4cc59216e1560c415acc"} 8
ei_jobruns_success{jobid="852b9ac6a1af4fbfae7dfec797799c73"} 1
ei_jobruns_success{jobid="93d348ed34ea4524b8c884ecde4d51c9"} 1
ei_jobruns_success{jobid="a3bf239a7dff44a6968099b2c844d982"} 913
ei_jobruns_success{jobid="a7d1cdc83e5a4df0a081b9fb16a4be49"} 1
ei_jobruns_success{jobid="b60761dd005b429baecc8776632dabfd"} 1
ei_jobruns_success{jobid="c20a91749cf24746bb0d8f11c442d02b"} 1
ei_jobruns_success{jobid="ccddcc2bae354f058252baef1585e670"} 1
ei_jobruns_success{jobid="d1df217f96d443d791294d43410c9e69"} 1
ei_jobruns_success{jobid="f2a7d02d8b5549dfae35a830565cf6e4"} 1
# HELP ei_jobruns_total_errors The total number of jobrun trigger attempts that errored
# TYPE ei_jobruns_total_errors counter
ei_jobruns_total_errors 0
# HELP ei_last_source_ping The timestamp of the last ping to the source
# TYPE ei_last_source_ping gauge
ei_last_source_ping{endpoint="birita-mock-http",jobid="93d348ed34ea4524b8c884ecde4d51c9"} 1.6112322731777287e+09
ei_last_source_ping{endpoint="bsc-mock-http",jobid="031bc83b1b9c479492af4a1dffa94a1b"} 1.6112322540436935e+09
ei_last_source_ping{endpoint="bsc-mock-ws",jobid="2f334446d386489b844bc3b3ead3cf89"} 1.6112280561106153e+09
ei_last_source_ping{endpoint="cfx-mock-http",jobid="451907c98fc7409fbbf5f3fa167e00cd"} 1.6112322638746903e+09
ei_last_source_ping{endpoint="cfx-mock-ws",jobid="ccddcc2bae354f058252baef1585e670"} 1.6112280659307928e+09
ei_last_source_ping{endpoint="eth-mock-http",jobid="0e5d60fa91ca461ca4dd719979c922b5"} 1.6112322416417022e+09
ei_last_source_ping{endpoint="eth-mock-ws",jobid="3007917f8f674fc08ad09a043a4d56c5"} 1.6112280437190046e+09
ei_last_source_ping{endpoint="hmy-mock-http",jobid="5f36cad8352b4cc59216e1560c415acc"} 1.6112322457530425e+09
ei_last_source_ping{endpoint="hmy-mock-ws",jobid="852b9ac6a1af4fbfae7dfec797799c73"} 1.6112280478233452e+09
ei_last_source_ping{endpoint="iotx-mock-grpc",jobid="283e8552b6da44ea82808f4bf99a914e"} 1.6112326132068512e+09
ei_last_source_ping{endpoint="keeper-mock-http",jobid="a7d1cdc83e5a4df0a081b9fb16a4be49"} 1.6112322689779768e+09
ei_last_source_ping{endpoint="keeper-mock-ws",jobid="b60761dd005b429baecc8776632dabfd"} 1.6112280700836205e+09
ei_last_source_ping{endpoint="near-mock-http",jobid="0d0008301a574ad39638ccd6161de88c"} 1.6112322742242055e+09
ei_last_source_ping{endpoint="ont-mock-http",jobid="c20a91749cf24746bb0d8f11c442d02b"} 1.6112326136707437e+09
ei_last_source_ping{endpoint="substrate-mock-ws",jobid="3397fdd971804484b279aa425006ab7b"} 1.611228077291971e+09
ei_last_source_ping{endpoint="substrate-mock-ws",jobid="d1df217f96d443d791294d43410c9e69"} 1.6112280814197373e+09
ei_last_source_ping{endpoint="substrate-mock-ws",jobid="f2a7d02d8b5549dfae35a830565cf6e4"} 1.6112280793605819e+09
ei_last_source_ping{endpoint="xtz-mock-http",jobid="a3bf239a7dff44a6968099b2c844d982"} 1.6112326138881707e+09
# HELP ei_subscriptions_active The total number of active subscriptions
# TYPE ei_subscriptions_active gauge
ei_subscriptions_active{endpoint="birita-mock-http"} 1
ei_subscriptions_active{endpoint="bsc-mock-http"} 1
ei_subscriptions_active{endpoint="bsc-mock-ws"} 1
ei_subscriptions_active{endpoint="cfx-mock-http"} 1
ei_subscriptions_active{endpoint="cfx-mock-ws"} 1
ei_subscriptions_active{endpoint="eth-mock-http"} 1
ei_subscriptions_active{endpoint="eth-mock-ws"} 1
ei_subscriptions_active{endpoint="hmy-mock-http"} 1
ei_subscriptions_active{endpoint="hmy-mock-ws"} 1
ei_subscriptions_active{endpoint="iotx-mock-grpc"} 1
ei_subscriptions_active{endpoint="keeper-mock-http"} 1
ei_subscriptions_active{endpoint="keeper-mock-ws"} 1
ei_subscriptions_active{endpoint="near-mock-http"} 1
ei_subscriptions_active{endpoint="ont-mock-http"} 1
ei_subscriptions_active{endpoint="substrate-mock-ws"} 3
ei_subscriptions_active{endpoint="xtz-mock-http"} 1
```