### PR TITLE
[ETH] Array of arrays and allowing empty array for topics.

### DIFF
--- a/blockchain/eth.go
+++ b/blockchain/eth.go
@@ -34,12 +34,12 @@ func createEthManager(p subscriber.Type, config store.Subscription) ethManager {
 	var topics [][]common.Hash
 	var t []common.Hash
 	for _, value := range config.Ethereum.Topics {
-		if len(value) < 1 {
+		if len(value) < 1 || value == "null" {
+			topics = append(topics, t)
 			continue
 		}
-		t = append(t, common.HexToHash(value))
+		topics = append(topics, append(t, common.HexToHash(value)))
 	}
-	topics = append(topics, t)
 
 	return ethManager{
 		fq: &filterQuery{


### PR DESCRIPTION
I was facing some issues trying to proper set `topics` for events.

I figured out that the mapper Job Spec's topics -> `ethManager.Topics` isn't working as expected.

From [common.go#L53](https://github.com/smartcontractkit/external-initiator/blob/master/blockchain/common.go#L53) the `Params.Topics` must be an array of strings.

But from [evm.go#L69](https://github.com/smartcontractkit/external-initiator/blob/master/blockchain/evm.go#L69), the `filterQuery.Topics` is an array of arrays (and that's correct).

Example:
```
{
    "initiators": [
        {
            "type": "external",
            "params": {
                "name": "myei2",
                "body": {
                    "endpoint": "eth-kovan",
                    "addresses": ["0xa36085F69e2889c224210F603D836748e7dC0088"],
                    "topics": [
                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
                        null,
                        "0x0000000000000000000000002f6e9d758ccb83d6564fcdd484527f4090062cd1"
                    ]
                }
            }
        }
       ],
    "tasks": [
        { ... }
    ]
}
```

This is being translated to:
`["0xddf252ad1be...3c4a11628f55a4df523b3ef", "0x00000000000...dd484527f4090062cd1"]`

But it should be:
`[["0xddf252ad1be...3c4a11628f55a4df523b3ef"], [],  ["0x00000000000...dd484527f4090062cd1"]]`

This PR is a first try to fix that.


