### PR TITLE
bump to 0.10.13 for integration testing

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM smartcontract/chainlink:latest
+FROM public.ecr.aws/chainlink/chainlink:0.10.13
 
 COPY ./docker-init-scripts/chainlink/import-keystore.sh ./
 


### PR DESCRIPTION
`chainlink:latest` is no longer a valid image tag. Using latest release in AWS ECR