### PR TITLE
fix(agoric): use BigInt strings for $LINK fee amounts

### DIFF
--- a/blockchain/agoric_test.go
+++ b/blockchain/agoric_test.go
@@ -188,14 +188,14 @@ func TestAgoricManager_ParseResponse(t *testing.T) {
 		{
 			"successfully parses WS Oracle request",
 			fields{filter: agoricFilter{JobID: "9999"}, p: subscriber.WS},
-			args{data: []byte(`{"type":"oracleServer/onQuery","data":{"query":{"jobID":"9999","params":{"path":"foo"}},"queryId":"123","fee":191919}}`)},
-			[]subscriber.Event{[]byte(`{"path":"foo","payment":"191919000000000000","request_id":"123"}`)},
+			args{data: []byte(`{"type":"oracleServer/onQuery","data":{"query":{"jobID":"9999","params":{"path":"foo"}},"queryId":"123","fee":"191919000000000000000"}}`)},
+			[]subscriber.Event{[]byte(`{"path":"foo","payment":"191919000000000000000","request_id":"123"}`)},
 			true,
 		},
 		{
 			"skips unfiltered WS Oracle request",
 			fields{filter: agoricFilter{JobID: "Z9999"}, p: subscriber.WS},
-			args{data: []byte(`{"type":"oracleServer/onQuery","data":{"query":{"jobID":"9999","params":{"path":"foo"}},"queryId":"123","fee":191919}}`)},
+			args{data: []byte(`{"type":"oracleServer/onQuery","data":{"query":{"jobID":"9999","params":{"path":"foo"}},"queryId":"123","fee":"191919"}}`)},
 			nil,
 			true,
 		},


### PR DESCRIPTION
At Agoric we have modified the bridged `$LINK` to use 18 decimal places, so the best way to represent these fee amounts is to use JSON strings.  We can remove the scaling hack that we needed before to translate between 6 decimals and 18 decimals.

This PR passes basic integration tests with our Oracle API.  Please merge.
