### PR TITLE
Updating Agoric's external initiator for Chainlink V2 Jobs

### DIFF
--- a/store/database.go
+++ b/store/database.go
@@ -158,7 +158,7 @@ func (client Client) prepareSubscription(rawSub *Subscription) (*Subscription, e
 			return nil, err
 		}
 	case "agoric":
-		if err := client.db.Model(&sub).Related(&sub.Agoric).Error; err != nil {
+		if err := client.db.Model(&sub).Error; err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
- Changing paths for job triggers 
- Removing the use of the database relation `agoric_subscriptions` because it is not being used
